### PR TITLE
Npg6 bugfix user role handling

### DIFF
--- a/hakimslivs/Pages/Admin/UserRoles/Index.cshtml.cs
+++ b/hakimslivs/Pages/Admin/UserRoles/Index.cshtml.cs
@@ -27,7 +27,7 @@ namespace hakimslivs.Pages.Admin.UserRoles
 
         public async Task<IActionResult> OnGetAsync()
         {
-            if (User.IsInRole("SuperAdmin, Admin"))
+            if (User.IsInRole("SuperAdmin") || User.IsInRole("Admin"))
             {
                 var users = await _userManager.Users.ToListAsync();
                 UserRolesViewModel = new List<UserRolesViewModel>();


### PR DESCRIPTION
Fixed wrong userrole-handling för superadmin and admin. Returned list was incorrect when admin was logged in, did not return all users.